### PR TITLE
Restructure POD interface

### DIFF
--- a/src/DataReduction/POD.jl
+++ b/src/DataReduction/POD.jl
@@ -25,21 +25,22 @@ end
 mutable struct POD{snapType} <: AbstractDRProblem
     # specified 
     snapshots::snapType
-    min_renergy
+    min_renergy::Any
     min_nmodes::Int
     max_nmodes::Int
     # computed
     nmodes::Int
-    rbasis
-    renergy
-    spectrum
-    function POD(snaps; 
+    rbasis::Any
+    renergy::Any
+    spectrum::Any
+    function POD(snaps;
                  min_renergy = 1.0,
-                 min_nmodes::Int = 1, 
+                 min_nmodes::Int = 1,
                  max_nmodes::Int = length(snaps[1]))
-        nmodes = min_nmodes 
+        nmodes = min_nmodes
         errorhandle(snaps, nmodes, min_renergy, min_nmodes, max_nmodes)
-        new{typeof(snaps)}(snaps, min_renergy, min_nmodes, max_nmodes, nmodes, missing, 1.0, missing)
+        new{typeof(snaps)}(snaps, min_renergy, min_nmodes, max_nmodes, nmodes, missing, 1.0,
+                           missing)
     end
     function POD(snaps, nmodes::Int)
         errorhandle(snaps, nmodes, 0.0, nmodes, nmodes)

--- a/src/DataReduction/POD.jl
+++ b/src/DataReduction/POD.jl
@@ -1,30 +1,30 @@
-function matricize(VoV::AbstractVector{T}) where {T <: AbstractVector}
+function matricize(VoV::Vector{Vector{T}}) where {T}
     Matrix(reduce(hcat, VoV))
 end
 
-function svd(data::AbstractVector{T}) where {T <: AbstractVector}
+function svd(data::Vector{Vector{T}}) where {T}
     mat_data = matricize(data)
     return svd(mat_data)
 end
 
-function svd(data::Vector{T}) where {T <: AbstractVector}
+function svd(data::Vector{Vector{T}}) where {T}
     mat_data = matricize(data)
     return svd(mat_data)
 end
 
-function tsvd(data::AbstractVector{T}, n::Int) where {T <: AbstractVector}
+function tsvd(data::Vector{Vector{T}}, n::Int) where {T}
     mat_data = matricize(data)
     return tsvd(mat_data, n)
 end
 
-function rsvd(data::AbstractVector{T}, n::Int, p::Int) where {T <: AbstractVector}
+function rsvd(data::Vector{Vector{T}}, n::Int, p::Int) where {T}
     mat_data = matricize(data)
     return rsvd(mat_data, n, p)
 end
 
-mutable struct POD{snapType} <: AbstractDRProblem
+mutable struct POD <: AbstractDRProblem
     # specified 
-    snapshots::snapType
+    snapshots::Any
     min_renergy::Any
     min_nmodes::Int
     max_nmodes::Int
@@ -33,18 +33,18 @@ mutable struct POD{snapType} <: AbstractDRProblem
     rbasis::Any
     renergy::Any
     spectrum::Any
+    # constructers
     function POD(snaps;
                  min_renergy = 1.0,
                  min_nmodes::Int = 1,
                  max_nmodes::Int = length(snaps[1]))
         nmodes = min_nmodes
         errorhandle(snaps, nmodes, min_renergy, min_nmodes, max_nmodes)
-        new{typeof(snaps)}(snaps, min_renergy, min_nmodes, max_nmodes, nmodes, missing, 1.0,
-                           missing)
+        new(snaps, min_renergy, min_nmodes, max_nmodes, nmodes, missing, 1.0, missing)
     end
     function POD(snaps, nmodes::Int)
         errorhandle(snaps, nmodes, 0.0, nmodes, nmodes)
-        new{typeof(snaps)}(snaps, 0.0, nmodes, nmodes, nmodes, missing, 1.0, missing)
+        new(snaps, 0.0, nmodes, nmodes, nmodes, missing, 1.0, missing)
     end
 end
 

--- a/src/DataReduction/POD.jl
+++ b/src/DataReduction/POD.jl
@@ -1,23 +1,23 @@
-function matricize(VoV::AbstractVector{T}) where T <: AbstractVector
+function matricize(VoV::AbstractVector{T}) where {T <: AbstractVector}
     Matrix(reduce(hcat, VoV))
 end
 
-function svd(data::AbstractVector{T}) where T <: AbstractVector 
+function svd(data::AbstractVector{T}) where {T <: AbstractVector}
     mat_data = matricize(data)
     return svd(mat_data)
 end
 
-function svd(data::Vector{T}) where T <: AbstractVector
+function svd(data::Vector{T}) where {T <: AbstractVector}
     mat_data = matricize(data)
     return svd(mat_data)
 end
 
-function tsvd(data::AbstractVector{T}, n::Int) where T <: AbstractVector 
+function tsvd(data::AbstractVector{T}, n::Int) where {T <: AbstractVector}
     mat_data = matricize(data)
     return tsvd(mat_data, n)
 end
 
-function rsvd(data::AbstractVector{T}, n::Int, p::Int) where T <: AbstractVector 
+function rsvd(data::AbstractVector{T}, n::Int, p::Int) where {T <: AbstractVector}
     mat_data = matricize(data)
     return rsvd(mat_data, n, p)
 end
@@ -25,11 +25,11 @@ end
 mutable struct POD{snapType} <: AbstractDRProblem
     snapshots::snapType
     nmodes::Int
-    rbasis
-    renergy
-    max_renergy 
+    rbasis::Any
+    renergy::Any
+    max_renergy::Any
     min_nmodes::Int
-    max_nmodes::Int 
+    max_nmodes::Int
     function POD(snaps::AbstractVector{T}, nmodes::Int; max_renergy = 1.0,
                  max_nmodes::Int = nmodes) where {T <: AbstractVector}
         errorhandle(snaps, nmodes, max_renergy, nmodes, max_nmodes)
@@ -37,7 +37,7 @@ mutable struct POD{snapType} <: AbstractDRProblem
     end
 
     function POD(snaps::AbstractMatrix, nmodes::Int = 1; max_renergy = 1.0,
-                 max_nmodes::Int = nmodes) 
+                 max_nmodes::Int = nmodes)
         errorhandle(snaps, nmodes, max_renergy, nmodes, max_nmodes)
         new{typeof(snaps)}(snaps, nmodes, nothing, 0.0, max_renergy, nmodes, max_nmodes)
     end
@@ -46,24 +46,25 @@ end
 function determine_truncation(s, min_nmodes, max_renergy, max_nmodes)
     nmodes = min_nmodes
     overall_energy = sum(s)
-    energy = sum(s[1:nmodes])/overall_energy
+    energy = sum(s[1:nmodes]) / overall_energy
     while energy < max_renergy && nmodes <= max_nmodes
         nmodes += 1
-        energy += s[nmodes+1]/overall_energy
+        energy += s[nmodes + 1] / overall_energy
     end
     return nmodes, energy
 end
 
 function reduce!(pod::POD, ::SVD)
     u, s, v = svd(pod.snapshots)
-    pod.nmodes, pod.renergy = determine_truncation(s, pod.min_nmodes, pod.max_nmodes, pod.max_renergy)
+    pod.nmodes, pod.renergy = determine_truncation(s, pod.min_nmodes, pod.max_nmodes,
+                                                   pod.max_renergy)
     pod.rbasis = u[:, 1:(pod.nmodes)]
     nothing
 end
 
 function reduce!(pod::POD, ::TSVD)
     u, s, v = tsvd(pod.snapshots, pod.nmodes)
-    n_max = min(size(u,1), size(v,1))
+    n_max = min(size(u, 1), size(v, 1))
     pod.renergy = sum(s) / (sum(s) + (n_max - pod.nmodes) * s[end])
     pod.rbasis = u
     nothing
@@ -71,7 +72,7 @@ end
 
 function reduce!(pod::POD, rsvd_alg::RSVD)
     u, s, v = rsvd(pod.snapshots, pod.nmodes, rsvd_alg.p)
-    n_max = min(size(u,1), size(v,1))
+    n_max = min(size(u, 1), size(v, 1))
     pod.renergy = sum(s) / (sum(s) + (n_max - pod.nmodes) * s[end])
     pod.rbasis = u
     nothing

--- a/src/DataReduction/POD.jl
+++ b/src/DataReduction/POD.jl
@@ -1,5 +1,5 @@
 function matricize(VoV::Vector{Vector{T}}) where {T}
-    Matrix(reduce(hcat, VoV))
+    reduce(hcat, VoV)
 end
 
 function svd(data::Vector{Vector{T}}) where {T}

--- a/src/DataReduction/POD.jl
+++ b/src/DataReduction/POD.jl
@@ -4,7 +4,7 @@ end
 
 function _svd(data::Vector{Vector{T}}; kwargs...) where {T}
     mat_data = matricize(data)
-    return svd(mat_data; kwargs...)
+    return _svd(mat_data; kwargs...)
 end
 
 _svd(data; kwargs...) = svd(data; kwargs...)

--- a/src/ErrorHandle.jl
+++ b/src/ErrorHandle.jl
@@ -1,5 +1,5 @@
-function errorhandle(data::Matrix{FT}, modes::IT) where {FT, IT}
+function errorhandle(data::AbstractMatrix, modes::Int)
     @assert size(data, 1)>1 "State vector is expected to be vector valued."
     s = size(data, 2)
-    @assert (modes > 0)&(modes < s) "Number of modes should be in {1,2,...,$(s-1)}."
+    @assert (modes >= 0)&(modes < s) "Number of modes should be in {1,2,...,$(s-1)}."
 end

--- a/src/ErrorHandle.jl
+++ b/src/ErrorHandle.jl
@@ -1,5 +1,15 @@
-function errorhandle(data::AbstractMatrix, modes::Int)
-    @assert size(data, 1)>1 "State vector is expected to be vector valued."
-    s = size(data, 2)
-    @assert (modes >= 0)&(modes < s) "Number of modes should be in {1,2,...,$(s-1)}."
+function errorhandle(data::AbstractMatrix, nmodes::Int, max_energy, min_nmodes, max_nmodes)
+    @assert size(data, 1) > 1 "State vector is expected to be vector valued."
+    s = minimum(size(data))
+    @assert 0 < nmodes <= s "Number of modes should be in {1,2,...,$s}."
+    @assert min_nmodes <= max_nmodes "Minimum number of modes must lie below maximum number of modes"
+    @assert 0.0 <= max_energy <= 1.0 "Maxmimum relative energy must be in [0,1]"
+end
+
+function errorhandle(data::AbstractVector{T}, nmodes::Int, max_energy, min_nmodes, max_nmodes) where {T <: AbstractVector}
+    @assert size(data[1], 1) > 1 "State vector is expected to be vector valued."
+    s = min(size(data, 1), size(data[1], 1))
+    @assert 0 < nmodes <= s "Number of modes should be in {1,2,...,$s}."
+    @assert min_nmodes <= max_nmodes "Minimum number of modes must lie below maximum number of modes"
+    @assert 0.0 <= max_energy <= 1.0 "Maxmimum relative energy must be in [0,1]"
 end

--- a/src/ErrorHandle.jl
+++ b/src/ErrorHandle.jl
@@ -1,15 +1,16 @@
 function errorhandle(data::AbstractMatrix, nmodes::Int, max_energy, min_nmodes, max_nmodes)
-    @assert size(data, 1) > 1 "State vector is expected to be vector valued."
+    @assert size(data, 1)>1 "State vector is expected to be vector valued."
     s = minimum(size(data))
-    @assert 0 < nmodes <= s "Number of modes should be in {1,2,...,$s}."
-    @assert min_nmodes <= max_nmodes "Minimum number of modes must lie below maximum number of modes"
-    @assert 0.0 <= max_energy <= 1.0 "Maxmimum relative energy must be in [0,1]"
+    @assert 0<nmodes<=s "Number of modes should be in {1,2,...,$s}."
+    @assert min_nmodes<=max_nmodes "Minimum number of modes must lie below maximum number of modes"
+    @assert 0.0<=max_energy<=1.0 "Maxmimum relative energy must be in [0,1]"
 end
 
-function errorhandle(data::AbstractVector{T}, nmodes::Int, max_energy, min_nmodes, max_nmodes) where {T <: AbstractVector}
-    @assert size(data[1], 1) > 1 "State vector is expected to be vector valued."
+function errorhandle(data::AbstractVector{T}, nmodes::Int, max_energy, min_nmodes,
+                     max_nmodes) where {T <: AbstractVector}
+    @assert size(data[1], 1)>1 "State vector is expected to be vector valued."
     s = min(size(data, 1), size(data[1], 1))
-    @assert 0 < nmodes <= s "Number of modes should be in {1,2,...,$s}."
-    @assert min_nmodes <= max_nmodes "Minimum number of modes must lie below maximum number of modes"
-    @assert 0.0 <= max_energy <= 1.0 "Maxmimum relative energy must be in [0,1]"
+    @assert 0<nmodes<=s "Number of modes should be in {1,2,...,$s}."
+    @assert min_nmodes<=max_nmodes "Minimum number of modes must lie below maximum number of modes"
+    @assert 0.0<=max_energy<=1.0 "Maxmimum relative energy must be in [0,1]"
 end

--- a/src/ModelOrderReduction.jl
+++ b/src/ModelOrderReduction.jl
@@ -7,6 +7,10 @@ using LinearAlgebra
 using TSVD
 using RandomizedLinAlg
 
+import TSVD.tsvd
+import RandomizedLinAlg.rsvd
+import LinearAlgebra.svd
+
 include("DataReduction/POD.jl")
 
 export SVD, TSVD, RSVD

--- a/src/ModelOrderReduction.jl
+++ b/src/ModelOrderReduction.jl
@@ -7,10 +7,6 @@ using LinearAlgebra
 using TSVD
 using RandomizedLinAlg
 
-import TSVD.tsvd
-import RandomizedLinAlg.rsvd
-import LinearAlgebra.svd
-
 include("DataReduction/POD.jl")
 
 export SVD, TSVD, RSVD

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -4,15 +4,15 @@ abstract type AbstractDRProblem <: AbstractReductionProblem end
 
 abstract type AbstractSVD end
 
-struct SVD <: AbstractSVD 
-    kwargs
+struct SVD <: AbstractSVD
+    kwargs::Any
     function SVD(; kwargs...)
         new(kwargs)
     end
 end
 
 struct TSVD <: AbstractSVD
-    kwargs
+    kwargs::Any
     function TSVD(; kwargs...)
         new(kwargs)
     end

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -3,11 +3,23 @@ abstract type AbstractMORProblem <: AbstractReductionProblem end
 abstract type AbstractDRProblem <: AbstractReductionProblem end
 
 abstract type AbstractSVD end
-struct SVD <: AbstractSVD end
-struct TSVD <: AbstractSVD end
+
+struct SVD <: AbstractSVD 
+    kwargs
+    function SVD(; kwargs...)
+        new(kwargs)
+    end
+end
+
+struct TSVD <: AbstractSVD
+    kwargs
+    function TSVD(; kwargs...)
+        new(kwargs)
+    end
+end
+
 struct RSVD <: AbstractSVD
     p::Int
-
     function RSVD(p::Int = 0)
         new(p)
     end

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -5,4 +5,10 @@ abstract type AbstractDRProblem <: AbstractReductionProblem end
 abstract type AbstractSVD end
 struct SVD <: AbstractSVD end
 struct TSVD <: AbstractSVD end
-struct RSVD <: AbstractSVD end
+struct RSVD <: AbstractSVD 
+    p::Int
+
+    function RSVD(p::Int=0)
+        new(p)
+    end
+end

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -5,10 +5,10 @@ abstract type AbstractDRProblem <: AbstractReductionProblem end
 abstract type AbstractSVD end
 struct SVD <: AbstractSVD end
 struct TSVD <: AbstractSVD end
-struct RSVD <: AbstractSVD 
+struct RSVD <: AbstractSVD
     p::Int
 
-    function RSVD(p::Int=0)
+    function RSVD(p::Int = 0)
         new(p)
     end
 end

--- a/test/DataReduction.jl
+++ b/test/DataReduction.jl
@@ -41,7 +41,7 @@ end
     @test size(matrix_reducer.rbasis, 1) == size(solution, 1)
     @test matrix_reducer.renergy > 0.9
 
-    reducer = POD(solution, 1, max_nmodes = 2, max_renergy = 0.1)
+    reducer = POD(solution, min_nmodes=1, max_nmodes = 2, min_renergy = 0.1)
     reduce!(reducer, solver)
     @test reducer.renergy > 0.1
     @test reducer.nmodes == 1

--- a/test/DataReduction.jl
+++ b/test/DataReduction.jl
@@ -29,31 +29,38 @@ end
 
     order = 2
     solver = SVD()
-    reducer = POD(solution, order)
+    matrix_reducer = POD(solution, order)
+    snapshot_reducer = POD(sol.u, order)
+    reduce!(matrix_reducer, solver)
+    reduce!(snapshot_reducer, solver)
+
+    @test all(matrix_reducer.rbasis .≈ snapshot_reducer.rbasis)
+    @test matrix_reducer.renergy ≈ snapshot_reducer.renergy
+    
+    @test size(matrix_reducer.rbasis, 2) == matrix_reducer.nmodes
+    @test size(matrix_reducer.rbasis, 1) == size(solution, 1)
+    @test matrix_reducer.renergy > 0.9
+
+    reducer = POD(solution, 1, max_nmodes = 2, max_renergy = 0.1)
     reduce!(reducer, solver)
-
-    reducer.renergy
-
-    # Ad-hoc tests. To be checked with Chris.
-    @test size(reducer.rbasis, 2) == reducer.nmodes
-    @test size(reducer.rbasis, 1) == size(solution, 1)
-    @test reducer.renergy > 0.9
+    @test reducer.renergy > 0.1
+    @test reducer.nmodes == 1
 
     order = 2
     solver = TSVD()
     reducer = POD(solution, order)
     reduce!(reducer, solver)
 
-    # Ad-hoc tests. To be checked with Chris.
     @test size(reducer.rbasis, 2) == reducer.nmodes
     @test size(reducer.rbasis, 1) == size(solution, 1)
+    @test reducer.renergy > 0.7
 
     order = 2
     solver = RSVD()
     reducer = POD(solution, order)
     reduce!(reducer, solver)
 
-    # Ad-hoc tests. To be checked with Chris.
     @test size(reducer.rbasis, 2) == reducer.nmodes
     @test size(reducer.rbasis, 1) == size(solution, 1)
+    @test reducer.renergy > 0.7
 end

--- a/test/DataReduction.jl
+++ b/test/DataReduction.jl
@@ -36,7 +36,7 @@ end
 
     @test all(matrix_reducer.rbasis .≈ snapshot_reducer.rbasis)
     @test matrix_reducer.renergy ≈ snapshot_reducer.renergy
-    
+
     @test size(matrix_reducer.rbasis, 2) == matrix_reducer.nmodes
     @test size(matrix_reducer.rbasis, 1) == size(solution, 1)
     @test matrix_reducer.renergy > 0.9

--- a/test/DataReduction.jl
+++ b/test/DataReduction.jl
@@ -41,7 +41,7 @@ end
     @test size(matrix_reducer.rbasis, 1) == size(solution, 1)
     @test matrix_reducer.renergy > 0.9
 
-    reducer = POD(solution, min_nmodes=1, max_nmodes = 2, min_renergy = 0.1)
+    reducer = POD(solution, min_nmodes = 1, max_nmodes = 2, min_renergy = 0.1)
     reduce!(reducer, solver)
     @test reducer.renergy > 0.1
     @test reducer.nmodes == 1


### PR DESCRIPTION
Hey, 

I revisited some of the POD interface and realized there were a few problems:

First of all, the type specs in the `POD` type are problematic: For example, specifiying integer-valued data will error as the rel. energy and the reduced basis is then constrained to be integer-valued as well (obviously not generally true): 
```
mutable struct POD{FT} <: AbstractDRProblem
    snapshots::Union{Vector{Vector{FT}}, Matrix{FT}}
    nmodes::Int
    rbasis::Matrix{FT}
    renergy::FT
```

Further, the interface did not accommodate a typical workflow for POD. Specifically, one often would like to reduce the dimensionality to capture a specified minimum relative energy (say 95%). Right now we require the dimension to be specified directly. So a user would effectively need to take the SVD of their data, look at the spectrum and decide on the cutoff, just to then take the svd all over again within ModelOrderReduction. I adjusted the POD type to also carry fields `min_renergy`, `min_nmodes`,  `max_nmodes`, referring to the min relative energy captured as well as the minimum and maximum number of modes retained, respectively. I updated the reduction step accordingly to choose the reduction to be inline with these specifications.  Moreover, I added a field `spectrum` that carries the singular spectrum (which is often of interest for a posterior analysis). 

Lastly, I changed the reduce statement to dispatch directly on the type of the data to be reduced. Consequently, POD can be applied via this interface to any data set which admits computation of a singular value decomposition via the specified routine. That way, everything composes better with the greater ecosystem.

Let me know! 
Flemming

