### PR TITLE
Set workstation type to 100 for headless systems in documentation CI

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -20,4 +20,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For authentication with GitHub Actions token
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }} # For authentication with SSH deploy key
+          GKSwstype: "100" # no output on headless systems
         run: julia --project=docs/ docs/make.jl


### PR DESCRIPTION
Resolve issue https://github.com/JuliaPlots/Plots.jl/issues/4368 for headless systems in documentation CI.

Reference: https://gr-framework.org/workstations.html#no-output