### PR TITLE
Update `deim` docstring to include types and default values of kwargs

### DIFF
--- a/src/deim.jl
+++ b/src/deim.jl
@@ -94,7 +94,14 @@ function deim(full_vars::AbstractVector, linear_coeffs::AbstractMatrix,
     reduced_rhss, linear_projection_eqs
 end
 """
-$(TYPEDSIGNATURES)
+    $(FUNCTIONNAME)(
+        sys::ModelingToolkit.ODESystem,
+        snapshot::AbstractMatrix,
+        pod_dim::Integer;
+        deim_dim::Integer = pod_dim,
+        name::Symbol = Symbol(nameof(sys), :_deim),
+        kwargs...
+    ) -> ModelingToolkit.ODESystem
 
 Reduce a `ModelingToolkit.ODESystem` using the Proper Orthogonal Decomposition (POD) with
 the Discrete Empirical Interpolation Method (DEIM).


### PR DESCRIPTION
`TYPEDSIGNATURES` from DocStringExtensions.jl doesn't show the types and default values of keyword arguments (https://github.com/JuliaDocs/DocStringExtensions.jl/issues/97 and https://github.com/JuliaDocs/DocStringExtensions.jl/issues/107). 
But they are important for one of the methods of `deim`.

This PR thus changes
![image](https://user-images.githubusercontent.com/45696147/195957578-060fc97c-0857-42ab-9124-306ccc74a4e6.png)
to
![image](https://user-images.githubusercontent.com/45696147/195957613-6dfeb860-d415-48d7-9fcd-9919bccceb4b.png)
