### PR TITLE
Add stable version of docs

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+    tags: [v*]
   pull_request:
 
 jobs:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -22,4 +22,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For authentication with GitHub Actions token
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }} # For authentication with SSH deploy key
           GKSwstype: "100" # no output on headless systems
-        run: julia --project=docs/ docs/make.jl
+        run: julia --project=docs/ --code-coverage=user docs/make.jl
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v1
+        with:
+          file: lcov.info


### PR DESCRIPTION
Previously I didn't configure the workflow correctly and Documenter.jl doesn't build documentation for tags.
This PR resolves it and also adds code in documentation to coverage.