### PR TITLE
Fix grammar and typo in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@
 
 ModelOrderReduction.jl is a package for automatically reducing the computational complexity
 of mathematical models, while keeping expected fidelity within a controlled error bound.
-These methods function a submodel with a projection
-where solving the smaller model gives approximation information about the full model.
+These methods construct a submodel via a projection
+where solving the smaller model gives approximate information about the full model.
 MOR.jl uses [ModelingToolkit.jl](https://docs.sciml.ai/ModelingToolkit/stable/)
 as a system description and automatically transforms equations
 to the subform, defining the observables to automatically lazily reconstruct the full

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -28,7 +28,7 @@ end
 """
 $(SIGNATURES)
 
-Returns `true` is `expr` contains variables in `dvs` only and does not contain `iv`.
+Returns `true` if `expr` contains variables in `dvs` only and does not contain `iv`.
 
 """
 function only_dvs(expr, dvs, iv)


### PR DESCRIPTION
## Summary

- Fix broken sentence in README.md: "These methods function a submodel" → "These methods construct a submodel via a projection"
- Fix "approximation information" → "approximate information" in README.md
- Fix typo in `src/utils.jl` docstring: "Returns true is" → "Returns true if"

## Test plan

- [x] Documentation builds successfully with no new warnings
- [x] Changes are grammatical/typographical fixes only, no functional changes

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)