### PR TITLE
Canonical CI cleanup: TagBot thin-caller + downgrade-caller cleanup

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -13,7 +13,4 @@ on:
 jobs:
   test:
     uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
-    with:
-      julia-version: "1.10"
-      skip: "Pkg,TOML"
     secrets: "inherit"

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,15 +1,9 @@
-name: TagBot
+name: "TagBot"
 on:
   issue_comment:
-    types:
-      - created
+    types: [created]
   workflow_dispatch:
 jobs:
-  TagBot:
-    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: JuliaRegistries/TagBot@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          ssh: ${{ secrets.DOCUMENTER_KEY }}
+  tagbot:
+    uses: "SciML/.github/.github/workflows/tagbot.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
Canonical CI cleanup:
- TagBot.yml: replaced inlined JuliaRegistries/TagBot with the canonical SciML thin caller (tagbot.yml@v1).
- Downgrade.yml: dropped the hand-listed skip (Pkg, TOML are stdlibs, auto-populated by the central workflow) and dropped the explicit julia-version 1.10 to take the central lts default.
- .typos.toml already present; no SpellCheck change needed.

Ignore until reviewed by @ChrisRackauckas.