### PR TITLE
Canonical CI: grouped-tests.yml + root test/test_groups.toml

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -18,22 +18,5 @@ concurrency:
 
 jobs:
   tests:
-    name: "Tests"
-    strategy:
-      fail-fast: false
-      matrix:
-        version:
-          - "1"
-          - "lts"
-          - "pre"
-        group:
-          - Core
-          - QA
-        exclude:
-          - version: "pre"
-            group: QA
-    uses: "SciML/.github/.github/workflows/tests.yml@v1"
-    with:
-      julia-version: "${{ matrix.version }}"
-      group: ${{ matrix.group }}
+    uses: "SciML/.github/.github/workflows/grouped-tests.yml@v1"
     secrets: "inherit"

--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -1,0 +1,5 @@
+[Core]
+versions = ["lts", "1", "pre"]
+
+[QA]
+versions = ["lts", "1"]


### PR DESCRIPTION
## Summary

Converts the root **Tests.yml** workflow into the canonical thin caller of `SciML/.github/.github/workflows/grouped-tests.yml@v1`, with the package's own test matrix declared once in a root **`test/test_groups.toml`**.

### Before
`Tests.yml` hand-maintained a `version × group` matrix calling `tests.yml@v1` directly:
- versions `{1, lts, pre}` × groups `{Core, QA}`, with `exclude: pre/QA`.

### After
`Tests.yml` is a thin caller:
```yaml
jobs:
  tests:
    uses: "SciML/.github/.github/workflows/grouped-tests.yml@v1"
    secrets: "inherit"
```
and the matrix lives in `test/test_groups.toml`:
```toml
[Core]
versions = ["lts", "1", "pre"]

[QA]
versions = ["lts", "1"]
```

No `with:` inputs are needed: the old job relied entirely on `tests.yml@v1` defaults (`check-bounds: yes`, `coverage: true`, `coverage-directories: src,ext`, standard `GROUP` env var read by `runtests.jl`), all of which the grouped-tests caller preserves. Linux-only, so no `os` field is set (default `ubuntu-latest`).

The `on:` triggers (pull_request + push on `main`, `paths-ignore: docs/**`), the `concurrency:` block, the workflow filename, and `name: "Tests"` are all preserved verbatim so branch-protection status checks remain intact. No other workflow files were touched.

### Matrix match: 5/5 exact

`julia scripts/compute_affected_sublibraries.jl . --root-matrix` emits:

| group | version | runner |
|-------|---------|--------|
| Core  | lts     | ubuntu-latest |
| Core  | 1       | ubuntu-latest |
| Core  | pre     | ubuntu-latest |
| QA    | lts     | ubuntu-latest |
| QA    | 1       | ubuntu-latest |

This is the identical 5-cell set the old `{1,lts,pre} × {Core,QA}` minus `pre/QA` matrix produced.

### QA

This repo already has `Core`/`QA` GROUP dispatch in `test/runtests.jl` (QA runs Aqua, ExplicitImports, JET). Per Category A this is a static matrix-verification only conversion — no `runtests.jl` change and no local Aqua/JET run. The `test_groups.toml` + `Tests.yml` both parse cleanly (TOML and YAML validated).

---

Ignore until reviewed by @ChrisRackauckas.