### PR TITLE
Use stiff solver in DEIM test

### DIFF
--- a/test/deim.jl
+++ b/test/deim.jl
@@ -38,10 +38,11 @@ order = 2
 discretization = MOLFiniteDifference(dxs, t; approx_order = order)
 ode_sys, tspan = symbolic_discretize(pde_sys, discretization)
 simp_sys = mtkcompile(ode_sys) # field substitutions is non-empty
-ode_prob = ODEProblem(
-    simp_sys, nothing, tspan;
-    missing_guess_value = ModelingToolkit.MissingGuessValue.Constant(0.0)
-)
+# The BCs fix every state to 0 at t=0, so provide those initial values directly.
+# Leaving them as missing guesses makes MethodOfLines' initialization system
+# structurally singular under MTK v11, and the least-squares solve diverges.
+u0 = [u => 0.0 for u in ModelingToolkit.get_unknowns(simp_sys)]
+ode_prob = ODEProblem(simp_sys, u0, tspan)
 sol = solve(ode_prob, Rodas5P(), saveat = 1.0)
 
 snapshot_simpsys = Array(sol.original_sol)

--- a/test/deim.jl
+++ b/test/deim.jl
@@ -42,7 +42,7 @@ ode_prob = ODEProblem(
     simp_sys, nothing, tspan;
     missing_guess_value = ModelingToolkit.MissingGuessValue.Constant(0.0)
 )
-sol = solve(ode_prob, Tsit5(), saveat = 1.0)
+sol = solve(ode_prob, Rodas5P(), saveat = 1.0)
 
 snapshot_simpsys = Array(sol.original_sol)
 pod_dim = 3
@@ -53,7 +53,7 @@ deim_sys = @test_nowarn deim(simp_sys, snapshot_simpsys, pod_dim)
 
 deim_prob = ODEProblem(complete(deim_sys), nothing, tspan)
 
-deim_sol = solve(deim_prob, Tsit5(), saveat = 1.0)
+deim_sol = solve(deim_prob, Rodas5P(), saveat = 1.0)
 
 nₓ = length(sol[x])
 nₜ = length(sol[t])


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## Summary
- Switch the DEIM PDE test from `Tsit5()` to `Rodas5P()` for both the full and reduced solves.
- Keeps the test on the current dependency stack while avoiding the one-timepoint `MaxIters` solution that makes POD fail before DEIM is exercised.

## Root Cause
`test/deim.jl` discretizes a stiff PDE-derived system but used the explicit `Tsit5()` solver. With current compatible dependencies, `Tsit5()` exhausts `maxiters`, MethodOfLines returns a one-timepoint solution, and `POD(snapshot, 3)` errors because the snapshot has only one time column.

Dependency boundary evidence from local probes:
- Current resolved stack fails: MethodOfLines 0.11.14, ModelingToolkit 11.31.1, PDEBase 0.1.27, OrdinaryDiffEq 7.1.2.
- Compatible older stack passes: MethodOfLines 0.11.12, ModelingToolkit 11.23.0, ModelingToolkitBase 1.41.0, ModelingToolkitTearing 1.15.0, PDEBase 0.1.24, with the current ODE/SciMLBase stack.
- First compatible post-floor stack fails: MethodOfLines 0.11.13, ModelingToolkit 11.27.0, ModelingToolkitBase 1.51.0, ModelingToolkitTearing 1.18.2, PDEBase 0.1.27.

## Validation
- `timeout 3600 env GROUP=Core /home/crackauc/.juliaup/bin/julia +release --project=. --startup-file=no -e 'using Pkg; Pkg.test(; coverage=false)'` passes.
- `Runic.main(["--check", "."])` with Runic v1.7.0 passes.

Co-Authored-By: Chris Rackauckas <accounts@chrisrackauckas.com>