### PR TITLE
Release prep: bump version to 0.1.9

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ModelOrderReduction"
 uuid = "207801d6-6cee-43a9-ad0c-f0c64933efa0"
 authors = ["Bowen S. Zhu <bowenzhu@mit.edu> and contributors"]
-version = "0.1.8"
+version = "0.1.9"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"


### PR DESCRIPTION
## Summary

Bumps the package version to pick up unreleased commits since the last registered
version (0.1.8, commit 35d5474).

Changes since 0.1.8:
- Add docstrings for already-exported `POD`, `reduce!`, `SVD`, `TSVD`, `RSVD`, and
  reference them from `docs/src/functions.md` (#163).
- Fix the DEIM test to provide explicit initial conditions and use `Rodas5P()`
  instead of `Tsit5()`, avoiding a structurally-singular initialization under
  MTK v11 (#164).
- Bump the `SciMLTesting` compat used by the test/QA harness (`test/Project.toml`,
  `test/qa/Project.toml`) from `1` to `2.1`. This is test-only tooling, not a
  dependency of the registered package, so no change to the package's own
  `[compat]` section was needed.

## Bump type: PATCH (0.1.8 -> 0.1.9)

No new exports, no public API changes, no behavior changes to the package itself
— only added documentation and test-only fixes/tooling bumps. Per SemVer this is
a patch-level change.

## Compat bounds

No changes to the main `Project.toml` `[compat]` section were required — the only
compat bump in the diff (`SciMLTesting`) is confined to the test/QA harness
Project.tomls and does not affect the registered package's dependency graph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)