### PR TITLE
Fix joint downgrade test resolution

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -7,10 +7,13 @@ on:
       - 'docs/**'
   push:
     branches:
-      - master
+      - main
     paths-ignore:
       - 'docs/**'
 jobs:
   test:
     uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
+    with:
+      group: "Core"
+      projects: ".,test"
     secrets: "inherit"


### PR DESCRIPTION
> [!IMPORTANT]
> Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

- resolve the root and `test` projects together in the downgrade job
- run the package's `Core` test group explicitly
- restore push-trigger coverage for the repository's `main` branch

## Root cause

The previous workflow downgraded only the root project. `Pkg.test` then activated the separate, pre-existing `test/Project.toml`, after the root manifest had already selected LinearSolve 5. That could not resolve with the minimum OrdinaryDiffEq 7 / OrdinaryDiffEqDefault 2 graph in the test environment.

The deployed downgrade action supports joint project resolution. Passing `projects: ".,test"` lets the resolver choose one compatible graph before `Pkg.test`; the final locked graph contains LinearSolve 4.3.0, OrdinaryDiffEq 7.1.3, and OrdinaryDiffEqDefault 2.3.0.

The workflow also watched `master`, but this repository's default branch is `main`, and it did not pass a test group to the SciMLTesting harness.

## Local verification

Julia 1.10.11 with the deployed v2.6.1 downgrade action in `deps` mode, resolving `.,test`, followed by a strict locked `GROUP=Core` test run:

```
Test Summary:         | Pass  Total      Time
Core/DataReduction.jl |   15     15  17m46.0s
Test Summary: | Pass  Total     Time
Core/deim.jl  |    4      4  5m12.0s
Test Summary: | Pass  Total  Time
Core/utils.jl |   10     10  2.0s
     Testing ModelOrderReduction tests passed
```

Additional checks passed:

- `Pkg.build()` on the exact locked graph
- `Runic --check .`
- `actionlint .github/workflows/Downgrade.yml`
- Project TOML parse
- `git diff --check`
