### PR TITLE
Give generated symbols deterministic names

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,3 +29,10 @@
   DEIM-sampled nonlinear terms are scalar expressions. Numeric matrices embedded as literals
   in a sum of array terms break `mtkcompile` (SymbolicUtils sorts them with `isless`), so
   keep them as parameters.
+- Generated symbol names must stay deterministic. `gensym` gives every reduced model fresh
+  names, so equivalent models never share generated code and each one recompiles. Names are
+  built from a fixed base plus `ModelOrderReduction.GENERATED_SUFFIX`, which contains `ˍ`
+  (U+02CD, the modifier letter ModelingToolkit uses for names like `xˍt`) so it cannot
+  collide with a name a user typed. Collisions with names inherited from the source system,
+  which happens when reducing an already-reduced model, are resolved by appending a counter.
+  Closes https://github.com/SciML/ModelOrderReduction.jl/issues/28.

--- a/src/deim.jl
+++ b/src/deim.jl
@@ -110,8 +110,58 @@ function Projection(fom::FullOrderModel, V::AbstractMatrix, U::AbstractMatrix)
     )
 end
 
-function _array_parameter(base::Symbol, value::AbstractArray)
-    name = gensym(base)
+"""
+Suffix marking the symbols this package generates.
+
+`ˍ` (U+02CD) is the modifier letter ModelingToolkit already uses for generated names such
+as `xˍt`. Using it keeps generated names out of the space of names a user is likely to
+type, while keeping them stable across calls so that equivalent reduced models share
+generated code instead of recompiling.
+"""
+const GENERATED_SUFFIX = "ˍmor"
+
+"""
+$(TYPEDSIGNATURES)
+
+Return a deterministic name derived from `base` that is not in `taken`, and reserve it.
+"""
+function _generated_name(base::Symbol, taken::Set{Symbol})
+    name = Symbol(base, GENERATED_SUFFIX)
+    index = 1
+    while name in taken
+        index += 1
+        name = Symbol(base, GENERATED_SUFFIX, index)
+    end
+    push!(taken, name)
+    return name
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Return the names of `fom` that the reduced system inherits, so generated names can avoid
+them. Reducing an already-reduced system is the case that makes this necessary.
+"""
+function _reserved_names(fom::FullOrderModel)
+    names = Set{Symbol}()
+    inherited = Iterators.flatten(
+        (
+            fom.parameters, (field.variable for field in fom.fields),
+            (equation.lhs for equation in fom.observed),
+        )
+    )
+    for item in inherited
+        value = Symbolics.unwrap(item)
+        if SymbolicUtils.iscall(value) && SymbolicUtils.operation(value) === getindex
+            value = first(SymbolicUtils.arguments(value))
+        end
+        push!(names, SymbolicIndexingInterface.getname(value))
+    end
+    return names
+end
+
+function _array_parameter(base::Symbol, value::AbstractArray, taken::Set{Symbol})
+    name = _generated_name(base, taken)
     parameter = if ndims(value) == 1
         (@parameters $name[1:length(value)])[1]
     else
@@ -129,14 +179,18 @@ algebra in the reduced state `reduced_state`.
 The projected matrices become array parameters of the reduced system, so the expression
 reads `A*ŷ + g + G*forcing + C*F`, where `forcing` holds the distinct symbolic forcing
 expressions and `F` the sampled nonlinear terms evaluated at the stencil rows of `V*ŷ`.
-Returns the expression together with the array parameters and their values. `kwargs` are
-forwarded to `Symbolics.substitute`.
+Returns the expression together with the array parameters and their values. Generated
+names avoid `taken` and are added to it. `kwargs` are forwarded to
+`Symbolics.substitute`.
 """
-function _reduced_rhs(fom::FullOrderModel, projection::Projection, reduced_state; kwargs...)
+function _reduced_rhs(
+        fom::FullOrderModel, projection::Projection, reduced_state, taken::Set{Symbol};
+        kwargs...
+    )
     parameters = Any[]
     values = Dict{Any, Any}()
     function array_parameter(base, value)
-        parameter, pair = _array_parameter(base, value)
+        parameter, pair = _array_parameter(base, value, taken)
         push!(parameters, first(pair))
         push!(values, pair)
         return parameter
@@ -209,16 +263,19 @@ function _reduced_system(
     iv = fom.iv
     D = Differential(iv)
     dim = size(V, 2)
-    state_name = gensym(:ŷ)
+    taken = _reserved_names(fom)
+    state_name = _generated_name(:ŷ, taken)
     reduced_state = (@variables $state_name(iv)[1:dim])[1]
     projection = Projection(fom, V, U)
-    rhs, array_parameters, array_values = _reduced_rhs(fom, projection, reduced_state; kwargs...)
+    rhs, array_parameters, array_values = _reduced_rhs(
+        fom, projection, reduced_state, taken; kwargs...
+    )
 
     reduced_snapshot = V' * Matrix{Float64}(snapshot[fom.rows, :])
     lift = Matrix{Float64}(snapshot) / reduced_snapshot
     lift[fom.rows, :] = V
     lift = lift[reduce(vcat, (field.rows for field in fom.fields)), :]
-    lift_parameter, lift_value = _array_parameter(:lift, lift)
+    lift_parameter, lift_value = _array_parameter(:lift, lift, taken)
 
     replacements = Dict{Any, Any}()
     reconstruction = Equation[]

--- a/test/array_structure.jl
+++ b/test/array_structure.jl
@@ -1,4 +1,5 @@
 using Test, ModelOrderReduction, ModelingToolkit
+import SymbolicIndexingInterface as SII
 
 @independent_variables t
 @variables u(t)[1:4]
@@ -35,6 +36,31 @@ snapshot = [sin(0.3 * i * j) + cos(0.2 * i * (j + 1)) for i in 1:4, j in 1:8]
             return tree_size(equation.lhs) + tree_size(equation.rhs)
         end
         @test graph_size(4) == graph_size(12)
+    end
+    @testset "deterministic generated names" begin
+        @mtkcompile sys = System([D(u) ~ -u - u .^ 3], t)
+        first_rom = deim(sys, snapshot, 2)
+        second_rom = deim(sys, snapshot, 2)
+        state_name(rom) = SII.getname(first(unknowns(rom)))
+        @test occursin(ModelOrderReduction.GENERATED_SUFFIX, String(state_name(first_rom)))
+        @test state_name(first_rom) == state_name(second_rom)
+        # Equal equations and parameters mean equal generated code, so a second reduction
+        # reuses the first one's compiled functions instead of recompiling.
+        @test isequal(only(equations(first_rom)), only(equations(second_rom)))
+        @test isequal(only(observed(first_rom)), only(observed(second_rom)))
+        @test isequal(parameters(first_rom), parameters(second_rom))
+    end
+    @testset "generated names avoid source names" begin
+        taken = Set([Symbol(:ŷ, ModelOrderReduction.GENERATED_SUFFIX)])
+        @test ModelOrderReduction._generated_name(:ŷ, taken) ==
+            Symbol(:ŷ, ModelOrderReduction.GENERATED_SUFFIX, 2)
+
+        @parameters ŷˍmor = 2.0
+        @mtkcompile sys = System([D(u) ~ -u - ŷˍmor * u .^ 3], t)
+        rom = deim(sys, snapshot, 2)
+        @test SII.getname(first(unknowns(rom))) ==
+            Symbol(:ŷ, ModelOrderReduction.GENERATED_SUFFIX, 2)
+        @test any(isequal(Symbolics.unwrap(ŷˍmor)), parameters(rom))
     end
     @testset "scalar input" begin
         @variables z₁(t) z₂(t)


### PR DESCRIPTION
Ignore this PR until reviewed by @ChrisRackauckas.

Closes https://github.com/SciML/ModelOrderReduction.jl/issues/28.

`deim` named the reduced state and its array parameters with `gensym`, so every reduction produced fresh names. Two reductions of the same system therefore built different symbolic expressions, which meant different `RuntimeGeneratedFunction`s and a full recompile of the problem, the residual, and the reconstruction each time. Names are now built from a fixed base plus `GENERATED_SUFFIX`, which is `ˍmor` — the `ˍ` is U+02CD, the modifier letter ModelingToolkit already uses for generated names such as `xˍt`, so it is outside the space of names a user would type.

Because the names are now shared rather than unique, the source system's own names have to be avoided. `_reserved_names` collects the names the reduced system inherits (kept parameters, source field variables, preserved observed left-hand sides) and `_generated_name` appends a counter when the base is taken. That case is reached by reducing an already-reduced model, whose parameters are named `Aˍmor`, `Cˍmor` and so on.

### Failing before, passing after

Reducing the same system twice, on `main` at 2439bac:

```text
first ROM state name:  ##ŷ#294
second ROM state name: ##ŷ#315
names equal:     false
equations equal: false
observed equal:  false
```

Same script on this branch:

```text
first ROM state name:  ŷˍmor
second ROM state name: ŷˍmor
names equal:     true
equations equal: true
observed equal:  true
```

The new `deterministic generated names` testset in `test/array_structure.jl` asserts the equal-equations and equal-parameters property, which is what makes the generated code shared; the `generated names avoid source names` testset covers the counter and a source system that already uses `ŷˍmor`.

### Measured effect

Three reductions of the same 24-state system in one session, reporting Julia's `@timed` compile-time counter for problem construction, the first residual evaluation, and the first field reconstruction:

| | construct (main) | rhs (main) | observed (main) | construct (branch) | rhs (branch) | observed (branch) |
|---|---:|---:|---:|---:|---:|---:|
| ROM 1 | 4.176 s | 0.588 s | 0.163 s | 4.213 s | 1.385 s | 0.162 s |
| ROM 2 | 0.936 s | 0.083 s | 0.041 s | 0.012 s | 0.0 s | 0.0 s |
| ROM 3 | 0.130 s | 0.082 s | 0.041 s | 0.0 s | 0.0 s | 0.0 s |

On `main` the per-reduction cost never amortizes: ROM 3 still pays the same 0.082 s and 0.041 s as ROM 2. On this branch it goes to zero, because the second reduction reuses the first one's compiled functions. The first reduction is unchanged; it is doing the compilation that the later ones now reuse.

### Verification

Julia 1.12.7, ModelingToolkit 11.41.0, MethodOfLines 1.3.0.

```sh
GROUP=Core julia +1 --project -e 'using Pkg; Pkg.test()'
```
```text
Core/DataReduction.jl   |   15     15  15.9s
Core/array_structure.jl |   15     15  33.8s
Core/deim.jl            |   58     58  4m05.4s
Core/full_order.jl      |   32     32   4.3s
Core/interface.jl       |   30     30   0.4s
     Testing ModelOrderReduction tests passed
```

```sh
GROUP=QA julia +1 --project -e 'using Pkg; Pkg.test()'
```
```text
QA/jet_tests.jl |    5      5  14.1s
QA/qa.jl        |   21     21  3m59.9s
     Testing ModelOrderReduction tests passed
```

```sh
GKSwstype=100 julia +1 --project=docs docs/make.jl
```
```text
[ Info: Doctest: running doctests.
exit status 0 (full build with the executed FitzHugh-Nagumo tutorial, doctests, and link checks)
```

`julia +1 --project=@runic -m Runic --check .`, `typos .`, and `git diff --check` all exit 0. The QA and docs runs above were made against the identical tree before the final rebase onto the merged `main`; the Core run is post-rebase.

### Not verified

- Julia LTS/prerelease and the downgrade configuration were not run locally.
- One Core run during development took 73 minutes rather than the usual 11. I traced that to precompilation contention in the shared depot with another job developing ModelingToolkit (`Being precompiled by another process`, and 233 dependencies loaded at different versions), not to this change: with warm caches every test file returns to its usual time, and `deim` itself is 0.01 s per call after the first. Worth knowing if CI ever looks slow for an unrelated reason.

### Review notes

- The generated names are now shared between reduced models in one session. That is the point, but it means two reduced models of *different* systems both call their state `ŷˍmor`. They are separate self-contained systems so nothing aliases across them, and the test suite exercises reduced models with POD dimensions 2, 3 and 4 in one session. Flagging it because it is the behavioral change a reviewer would most reasonably question.
- `GENERATED_SUFFIX` is not exported and is not documented as public API; the tests reach into it so that they do not hard-code the spelling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5RuLDtEazwTKPkNbPeZVu
