### PR TITLE
Give the POD reduced system its own time span

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,8 +25,8 @@
 - Source systems must list scalar unknowns (scalarized array elements or `mtkcompile`
   output). A `System` built without explicit unknowns collects both an array variable and
   its indexed elements, which no problem constructor accepts either.
-- Both `DAEProblem(rom, nothing, tspan; build_initializeprob = false)` and
-  `ODEProblem(mtkcompile(rom), nothing, tspan; build_initializeprob = false)` are supported
+- Both `DAEProblem(rom, nothing; build_initializeprob = false)` and
+  `ODEProblem(mtkcompile(rom), nothing; build_initializeprob = false)` are supported
   and tested. Reconstruct fields with `SymbolicIndexingInterface.observed`; the `sol[field]`
   convenience path hits https://github.com/SciML/ModelingToolkit.jl/issues/5072.
 - The reduced equation is array linear algebra: projected matrices, the stencil rows of the
@@ -41,3 +41,10 @@
   collide with a name a user typed. Collisions with names inherited from the source system,
   which happens when reducing an already-reduced model, are resolved by appending a counter.
   Closes https://github.com/SciML/ModelOrderReduction.jl/issues/28.
+- The reduced system inherits a time span, for both `deim` and `pod`: from `prob.tspan` for
+  the problem method, and from `get_tspan(sys)` for the system method. A source without a
+  time span must yield a reduced system without one rather than a fabricated interval, and a
+  new reduction entry point has to thread `tspan` into `_assemble_reduced_system` the same
+  way. This needs the `tspan` field on `ModelingToolkit.System`, added in
+  ModelingToolkitBase 1.69.0 and guaranteed only from ModelingToolkit 11.42.0.
+  Closes https://github.com/SciML/ModelOrderReduction.jl/issues/29.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ sol = solve(full_prob)
 
 # POD Galerkin: one array reduced equation, O(1) symbolic residual in the grid size
 rom = pod(full_prob, sol, 4)
-rom_prob = DAEProblem(rom, nothing, full_prob.tspan; build_initializeprob = false)
+rom_prob = DAEProblem(rom, nothing; build_initializeprob = false)
 rom_sol = solve(rom_prob)
 z_approx = [SII.observed(rom, z)(u, rom_prob.p, tt) for (u, tt) in zip(rom_sol.u, rom_sol.t)]
 ```

--- a/src/pod.jl
+++ b/src/pod.jl
@@ -307,7 +307,8 @@ end
 
 function _pod(
         sys::System, snapshot::AbstractMatrix, pod_dim::Integer, name::Symbol;
-        snapshot_times = nothing, training_parameters = Dict{Any, Any}(), kwargs...
+        snapshot_times = nothing, training_parameters = Dict{Any, Any}(),
+        tspan = nothing, kwargs...
     )
     rows = length(ModelingToolkit.unknowns(sys))
     size(snapshot, 1) == rows || throw(
@@ -339,7 +340,7 @@ function _pod(
             )
             return _assemble_reduced_system(
                 fom, snapshot, state_basis, reduced_state, rhs, array_parameters,
-                array_values, taken, name, initial_derivative; kwargs...
+                array_values, taken, name, initial_derivative; tspan, kwargs...
             )
         end
     end
@@ -353,7 +354,7 @@ function _pod(
     )
     return _assemble_reduced_system(
         fom, snapshot, state_basis, reduced_state, rhs, array_parameters, array_values,
-        taken, name, initial_derivative; kwargs...
+        taken, name, initial_derivative; tspan, kwargs...
     )
 end
 
@@ -386,6 +387,10 @@ scales with the full-order dimension (use [`deim`](@ref) to hyper-reduce it).
 needed. The returned system always has one array differential equation for the reduced
 state and one reconstruction observed equation per source field. Unknowns eliminated during
 simplification are reconstructed by a least-squares fit to `snapshot`.
+
+The reduced system inherits the time span of `sys`, so a problem can be built from it
+without repeating one. Passing a time span explicitly still overrides it, and a source
+system without one produces a reduced system without one.
 
 Construct a `DAEProblem` with `build_initializeprob = false` from the returned system to
 keep array code generation, or call `ModelingToolkit.mtkcompile` on it and construct an
@@ -421,7 +426,10 @@ function pod(
         sys::System, snapshot::AbstractMatrix, pod_dim::Integer;
         name::Symbol = Symbol(nameof(sys), :_pod), snapshot_times = nothing, kwargs...
     )::System
-    return _pod(sys, snapshot, pod_dim, name; snapshot_times, kwargs...)
+    return _pod(
+        sys, snapshot, pod_dim, name;
+        snapshot_times, tspan = ModelingToolkit.get_tspan(sys), kwargs...
+    )
 end
 
 """
@@ -440,6 +448,8 @@ saved solutions `sol` as the training snapshot.
 `DAEProblem` returned by MethodOfLines. The saved states are the snapshot columns, the
 saved times supply the independent variable for time-dependent terms, and the parameter
 values of `prob` are used for training and become the defaults of the reduced system.
+The reduced system also inherits the time span of `prob`, which is the interval it was
+trained on, so a problem can be built from it without repeating one.
 `sol` may be the `SciMLBase.PDETimeSeriesSolution` returned by MethodOfLines or its
 underlying `SciMLBase.AbstractODESolution`. See the system method for the reduction itself
 and for how to construct problems from the returned system.
@@ -469,7 +479,7 @@ full_problem = discretize(pde_system, discretization; fallback = false)
 full_solution = solve(full_problem)
 reduced_system = pod(full_problem, full_solution, 4)
 reduced_problem = DAEProblem(
-    reduced_system, nothing, full_problem.tspan; build_initializeprob = false
+    reduced_system, nothing; build_initializeprob = false
 )
 ```
 """
@@ -496,7 +506,7 @@ function pod(
     reduced_name = isnothing(name) ? Symbol(nameof(sys), :_pod) : name
     return _pod(
         sys, snapshot, pod_dim, reduced_name;
-        snapshot_times = sol.t, training_parameters, kwargs...
+        snapshot_times = sol.t, training_parameters, tspan = prob.tspan, kwargs...
     )
 end
 

--- a/test/deim.jl
+++ b/test/deim.jl
@@ -71,10 +71,9 @@ reconstruction_parameters = filter(ModelingToolkit.get_ps(deim_sys)) do paramete
 end
 @test length(reconstruction_parameters) == 1
 
-deim_prob = DAEProblem(
-    deim_sys, nothing, full_prob.tspan;
-    build_initializeprob = false,
-)
+# No time span here: the reduced system carries the one it was trained on.
+deim_prob = DAEProblem(deim_sys, nothing; build_initializeprob = false)
+@test deim_prob.tspan == full_prob.tspan
 
 deim_sol = solve(deim_prob; saveat = 1.0)
 @test successful_retcode(deim_sol)

--- a/test/pod.jl
+++ b/test/pod.jl
@@ -128,3 +128,28 @@ end
     )
     @test norm(reconstruction - truth) / norm(truth) < 0.01
 end
+
+@testset "the POD reduced system carries a tspan" begin
+    @variables g(t)[1:6]
+    g0 = [0.4, 0.3, 0.2, 0.1, -0.2, 0.5]
+    gstates = ModelingToolkit.Symbolics.unwrap.(ModelingToolkit.Symbolics.scalarize(g))
+    span = (0.0, 0.5)
+    @named source = System(
+        [D(g) ~ -g - g .^ 3], t, gstates, [];
+        initial_conditions = [g => g0, D(g) => -g0 - g0 .^ 3],
+    )
+    source_problem = DAEProblem(complete(source), nothing, span; build_initializeprob = false)
+    source_solution = solve(source_problem; saveat = 0.05, abstol = 1.0e-10, reltol = 1.0e-10)
+    @test successful_retcode(source_solution)
+
+    from_problem = pod(source_problem, source_solution, 3)
+    @test ModelingToolkit.get_tspan(from_problem) == span
+    @test DAEProblem(from_problem, nothing; build_initializeprob = false).tspan == span
+
+    snapshot = [sin(0.3 * i * j) + cos(0.2 * i * (j + 1)) for i in 1:6, j in 1:8]
+    @mtkcompile with_span = System([D(g) ~ -g - g .^ 3], t; tspan = span)
+    @test ModelingToolkit.get_tspan(pod(with_span, snapshot, 2)) == span
+
+    @mtkcompile without_span = System([D(g) ~ -g - g .^ 3], t)
+    @test ModelingToolkit.get_tspan(pod(without_span, snapshot, 2)) === nothing
+end


### PR DESCRIPTION
Ignore this PR until reviewed by @ChrisRackauckas.

Finishes the ModelOrderReduction side of https://github.com/SciML/ModelOrderReduction.jl/issues/29, in 1.0.0 before it is released. No version bump: General still has 0.1.11, so 1.0.0 has never shipped and this lands as part of it.

https://github.com/SciML/ModelOrderReduction.jl/pull/181 gave `deim` an inherited time span, but `pod` arrived in parallel through https://github.com/SciML/ModelOrderReduction.jl/pull/202 and did not get one. So the POD Galerkin example in the README still read:

```julia
rom_prob = DAEProblem(rom, nothing, full_prob.tspan; build_initializeprob = false)
```

which is exactly the out-of-band time-span threading issue 29 is about. `pod` now inherits one on the same terms as `deim`:

```julia
rom = pod(full_prob, sol, 4)
rom_prob = DAEProblem(rom, nothing; build_initializeprob = false)
```

### What changed

- `_pod` takes a `tspan` and forwards it into the shared `_assemble_reduced_system`, on both the array and the compiled-fallback paths. That function already accepted the keyword, so this is a thread-through rather than new machinery.
- The problem method uses `prob.tspan`, the interval the reduction was trained on. The system method uses `get_tspan(sys)`. A source without a span still yields a reduced system without one, rather than a fabricated interval, and passing one explicitly still overrides.
- The README POD example, the `pod` docstring example, and the FitzHugh-Nagumo DEIM test drop the now-redundant argument. That test now asserts `deim_prob.tspan == full_prob.tspan`, so the inherited span is checked end to end through MethodOfLines rather than merely being unused.
- `AGENTS.md` records the convention. Its note from #181 never actually reached main: the squash merge of that PR did not carry the file, which I confirmed with `git log -S`. This restores it covering both entry points, and corrects a now-stale line claiming a time span must be passed to build a problem.

Two `full_problem.tspan` uses remain in `test/pod.jl`. They are deliberate: they exercise the explicit-override path, which still has to work.

### Verification

Julia 1.12.7, against ModelingToolkit 11.42.0 and ModelingToolkitBase 1.69.0 from the registry.

```text
=== pod exit 0 (1111s)
POD graph size is grid-independent for array equations |    1      1   2.3s
scalarized POD Galerkin fallback                       |    5      5   7.8s
parameterized array POD                                |    5      5   5.2s
the POD reduced system carries a tspan                 |    5      5   2.2s

=== deim exit 0 (260s)
training parameters and nonautonomous nonlinearities   |    4      4   3.2s
ODEProblem sources and scalar code generation          |    9      9  18.4s
nonautonomous linear terms                             |    5      5   3.2s
the reduced system carries a tspan                     |    8      8   2.7s
```

The new `pod` testset covers all four cases: inherited from the problem, inherited from the system, absent when the source has none, and the problem building without an explicit span.

`Runic --check .`, `typos`, and `git diff --check` all exit 0.

### Not verified

- `GROUP=QA` and the docs build were not re-run; this adds no public name and changes no import. The README edit is not executed by the docs build.
- Julia LTS and prerelease, and the downgrade configuration, were not run locally.

### The rest of the chain, for context

ModelingToolkitBase 1.69.0 added the `System` field, ModelingToolkit 11.42.0 raised the floor that guarantees it, and PDEBase 0.1.35 sets the span on the system `symbolic_discretize` returns, so a MethodOfLines discretization carries the PDE's own `t` domain. All three are registered. https://github.com/SciML/MethodOfLines.jl/pull/685 raises its floors to match and is still open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5RuLDtEazwTKPkNbPeZVu
