### PR TITLE
Add AirspeedVelocity benchmarking CI

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,29 @@
+name: Benchmark this PR
+
+on:
+  pull_request:
+    branches: [main]
+    paths-ignore: ['docs/**']
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ["1", "lts"]
+    env:
+      # Force consistent Julia depot path for self-hosted runners
+      JULIA_DEPOT_PATH: ~/.julia
+    steps:
+      - uses: MilesCranmer/AirspeedVelocity.jl@action-v1
+        with:
+          julia-version: ${{ matrix.version }}
+          script: "benchmark/benchmarks.jl"
+          extra-pkgs: "ModelingToolkit"
+          job-summary: true

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,32 @@
+using ModelOrderReduction, BenchmarkTools
+using ModelingToolkit
+
+const SUITE = BenchmarkGroup()
+
+@independent_variables t
+@variables u(t)[1:4]
+D = Differential(t)
+snapshot = [
+    sin(0.3 * i * j) + cos(0.2 * i * (j + 1)) for i in 1:4, j in 1:8
+]
+
+@mtkcompile sys = System([D(u) ~ -u - u .^ 3], t)
+csys = complete(sys)
+
+# =============================================================================
+# DEIM reduction (symbolic system + snapshot matrix)
+# =============================================================================
+
+SUITE["deim"] = BenchmarkGroup()
+
+SUITE["deim"]["deim_2"] = @benchmarkable deim($csys, $snapshot, 2)
+SUITE["deim"]["deim_3"] = @benchmarkable deim($csys, $snapshot, 3)
+
+# =============================================================================
+# POD-Galerkin reduction
+# =============================================================================
+
+SUITE["pod"] = BenchmarkGroup()
+
+SUITE["pod"]["pod_2"] = @benchmarkable pod($csys, $snapshot, 2)
+SUITE["pod"]["pod_3"] = @benchmarkable pod($csys, $snapshot, 3)


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/benchmark.yml` running AirspeedVelocity on pull requests (Julia `1` and `lts`, 30 min timeout), following the OrdinaryDiffEq.jl setup.
- Adds `benchmark/benchmarks.jl` with a small `SUITE` covering representative workloads for this package.

The suite was verified locally in a fresh environment: it loads and all benchmarks run in ~54s.

#### Test plan

- [x] `run(SUITE)` locally: all benchmarks pass (~54s)
- [x] Runic formatting clean on `benchmark/benchmarks.jl`
- [ ] \"Benchmark this PR\" workflow triggers and completes on this PR

🤖 Generated with [Devin](https://devin.ai) (harness: devin 3000.10.21, model: SWE-2 Max)
Session: local transcript /home/crackauc/.local/share/devin/cli/summaries/history_ccb52064e6514b21.md