### PR TITLE
Drop `/` and `\` from the `LinearAlgebra` import

### DIFF
--- a/src/ModelOrderReduction.jl
+++ b/src/ModelOrderReduction.jl
@@ -8,7 +8,7 @@ using ModelingToolkit: ModelingToolkit, @parameters, @variables, Differential, E
     System, SymbolicUtils, Symbolics, complete, mtkcompile, substitute
 using SciMLBase: SciMLBase
 using SymbolicIndexingInterface: SymbolicIndexingInterface
-using LinearAlgebra: LinearAlgebra, /, \, mul!, qr, svd, lyap, Symmetric, Diagonal,
+using LinearAlgebra: LinearAlgebra, mul!, qr, svd, lyap, Symmetric, Diagonal,
     eigen, eigvals, I, factorize, norm, ColumnNorm
 using SparseArrays: SparseArrays, SparseMatrixCSC, findnz, sparse
 


### PR DESCRIPTION
## Summary

The QA job on the `julia '1'` lane (Julia 1.13.0) fails two ExplicitImports checks because `/` and `\` are imported from `LinearAlgebra`, while their owner is `Base`:

- `all_explicit_imports_via_owners`: `` `/` and `\` have owner `Base` but were imported from `LinearAlgebra` ``
- `all_explicit_imports_are_public`: `` `/` and `\` are not public in `LinearAlgebra` ``

Failing run: https://github.com/SciML/ModelOrderReduction.jl/actions/runs/34675969798

Both names are only called, never extended, and `Base` exports them — dropped from the import list.

Note: the `Downgrade` workflow failure on this branch is the known `OrdinaryDiffEqDefault`/`OrdinaryDiffEqCore` compat issue that was fixed in the General registry (JuliaRegistries/General#167989) after this run raced the registration — a re-run should pick up consistent bounds.

## Test plan

- [x] `GROUP=QA julia --project -e 'using Pkg; Pkg.test()'` passes on Julia 1.13.0 (the two EI checks errored in CI on the unfixed code)
- [ ] CI

🤖 Generated with Devin CLI 3000.10.21 (model: SWE-2 Max). Session: local session, `/home/crackauc/.local/share/devin/cli/sessions.db`