### PR TITLE
Release ModelOrderReduction 1.1.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ModelOrderReduction"
 uuid = "207801d6-6cee-43a9-ad0c-f0c64933efa0"
 authors = ["Bowen S. Zhu <bowenzhu@mit.edu> and contributors"]
-version = "1.1.0"
+version = "1.1.1"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"


### PR DESCRIPTION
Bumps `ModelOrderReduction` 1.1.0 -> 1.1.1 (patch).

Source files changed since 1.1.0:
- `src/ModelOrderReduction.jl`

Commits:
- Add AirspeedVelocity benchmarking CI (#207)
- Drop `/` and `\` from the `LinearAlgebra` import (#208)

Version bump only; no code changes in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
